### PR TITLE
BOF-20 Fix inaccessible about page redirects to properties

### DIFF
--- a/webapp/main/templatetags/sidebar_links.py
+++ b/webapp/main/templatetags/sidebar_links.py
@@ -2,6 +2,8 @@ from django import template
 
 register = template.Library();
 
+#look for your icon here https://fontawesome.com/search?ic=free
+
 @register.simple_tag
 def get_links():
     return [{
@@ -9,9 +11,9 @@ def get_links():
         'href': '/',
         'icon': 'fa-house',
     }, {
-        'name': 'Cars',
-        'href': '/cars',
-        'icon': 'fa-car',
+        'name': 'Properties',
+        'href': '/properties',
+        'icon': 'fa-house-lock',
     }, {
         'name': 'Contact',
         'href': '/contact',
@@ -20,17 +22,5 @@ def get_links():
         'name': 'About',
         'href': '/about',
         'icon': 'fa-address-card',
-    },{
-        'name': 'News',
-        'href': '/news/',
-        'icon': 'fa-newspaper',
-    },{
-        'name': 'Add news',
-        'href': '/news/create',
-        'icon': 'fa-plus',
-    },{
-        'name': 'Forum',
-        'href': '/forum',
-        'icon': 'fa-comment', #look for your icon here https://fontawesome.com/search?ic=free
     }]
     

--- a/webapp/main/urls.py
+++ b/webapp/main/urls.py
@@ -1,13 +1,11 @@
 # Plik do zarządzania ścieżkami w aplikacji. Zawiera listę ścieżek powiązanych z widokami.
 
 from django.urls import path
-from django.urls import path
 from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),  # Home page (example)
     path('contact/', views.contact, name='contact'),  # Contact page
     path('properties/', views.properties, name='properties'),  # Properties page
+    path('about/', views.about, name='about')
 ]
-
-

--- a/webapp/main/views.py
+++ b/webapp/main/views.py
@@ -3,11 +3,14 @@
 from django.shortcuts import render
 
 # Create your views here.
-def properties(request):
-    return render(request, 'main/properties.html')
+def index(request):
+    return render(request, 'main/index.html')
 
 def contact(request):
     return render(request, 'main/contact.html')
 
-def index(request):
-    return render(request, 'main/index.html')
+def properties(request):
+    return render(request, 'main/properties.html')
+
+def about(request):
+    return render(request, 'main/about.html')

--- a/webapp/webapp/urls.py
+++ b/webapp/webapp/urls.py
@@ -23,4 +23,4 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('main.urls')), 
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
* brings `/about` page back
* adds `Properties` to sidebar, cc: @Tolkovika 
* removes excess items from the sidebar